### PR TITLE
swap out memcached for redis

### DIFF
--- a/django/ealgis/settings.py
+++ b/django/ealgis/settings.py
@@ -190,8 +190,11 @@ WSGI_APPLICATION = 'ealgis.wsgi.application'
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': get_env('MEMCACHED_LOCATION'),
+        'BACKEND': 'redis_lock.django_cache.RedisCache',
+        'LOCATION': get_env('REDIS_LOCATION'),
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient'
+        }
     }
 }
 

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -9,7 +9,6 @@ SQLAlchemy==1.2.12
 GeoAlchemy2==0.5.0
 pyparsing==2.2.2
 requests==2.19.1
-python-memcached==1.59
 mercantile==1.0.4
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
@@ -18,3 +17,6 @@ uwsgi==2.0.17.1
 zipstream==1.1.4
 https://github.com/ealgis/ealgis-data-schema/archive/1.1.1.tar.gz
 https://github.com/ealgis/ealgis-common/archive/0.6.0.tar.gz
+django-redis==4.9.0
+python-redis-lock[django]==3.2.0
+redis==2.10.6

--- a/docker-compose-buildpy.yml
+++ b/docker-compose-buildpy.yml
@@ -19,10 +19,8 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=ealgis
-  memcached:
-    image: memcached
-    expose:
-      - "11211"
+  redis:
+    image: redis:5-alpine
   web:
     build: django/
     command: build
@@ -31,7 +29,7 @@ services:
       - ./build/:/build:delegated
       - ./frontend:/frontend:delegated
     environment:
-      - MEMCACHED_LOCATION=memcached:11211
+      - REDIS_LOCATION=redis://redis:6379/1
       - DB_HOST=db
       - DB_PORT=5432
       - DB_NAME=ealgis
@@ -47,4 +45,4 @@ services:
     depends_on:
       - db
       - datastore
-      - memcached
+      - redis

--- a/docker-compose-dataloader.yml
+++ b/docker-compose-dataloader.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./loaders:/app
     environment:
-      - MEMCACHED_LOCATION=memcached:11211
+      - REDIS_LOCATION=redis://redis:6379/1
       - DB_HOST=datastore
       - DB_PORT=5432
       - DB_NAME=postgres

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -10,15 +10,15 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=ealgis
-  memcached:
-    image: memcached
+  redis:
+    image: redis:5-alpine
   uwsgi:
     image: ealgis/uwsgi:latest
     command: uwsgi
     volumes:
       - ./log/:/var/log:delegated
     environment:
-      - MEMCACHED_LOCATION=memcached:11211
+      - REDIS_LOCATION=redis://redis:6379/1
       - DB_HOST=db
       - DB_PORT=5432
       - DB_NAME=ealgis
@@ -34,7 +34,7 @@ services:
     depends_on:
       - db
       - datastore
-      - memcached
+      - redis
   nginx-prod:
     image: ealgis/nginx:latest
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,8 @@ services:
       - ./nginx-dev/nginx:/nginx
     ports:
       - "127.0.0.1:35729:35729"
-  memcached:
-    image: memcached
-    expose:
-      - "11211"
+  redis:
+    image: redis:5-alpine
   web:
     build: django/
     command: runserver
@@ -46,7 +44,7 @@ services:
     ports:
       - "127.0.0.1:8000:8000"
     environment:
-      - MEMCACHED_LOCATION=memcached:11211
+      - REDIS_LOCATION=redis://redis:6379/1
       - DB_HOST=db
       - DB_PORT=5432
       - DB_NAME=ealgis
@@ -62,7 +60,7 @@ services:
     depends_on:
       - db
       - datastore
-      - memcached
+      - redis
       - frontend
   nginx-dev:
     build: nginx-dev/


### PR DESCRIPTION
Use distributed locks to avoid the thundering herd problem.

Note that a container rebuild is required after this change,
and that production environments will need to swap over to
redis rather than memcached. The new environment variable
REDIS_LOCATION replaces MEMCACHED_LOCATION.