### PR TITLE
Add Python Social Auth settings variables for custom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ EALGIS supports custom OAuth2 providers through [pluggable backends](http://pyth
 ```python
 class CustomOAuth2(BaseOAuth2):
     """Our custom OAuth2 authentication backend"""
-    name = 'myprovidername'
+    name = 'custom'
     title = 'Our Custom Provider'
 ```
 
+Ensure the class variable name holds the value 'custom'. Python Social Auth settings variables for authentication providers are based on the provider name. EALGIS will recognise your provider if you name it 'custom'.
+ 
 2.  Use Docker volumes to inject the file into the `web` container at `/app/ealgis/ealauth/backends.py`
 
 3.  To validate that your provider is available check the output of `https://localhost/api/0.1/config` for

--- a/django/ealgis/settings.py
+++ b/django/ealgis/settings.py
@@ -141,6 +141,8 @@ if get_env('SOCIAL_AUTH_TWITTER_KEY') is not None:
 
 if os.path.isfile("ealgis/ealauth/backends.py"):
     AUTH_BACKENDS.append("ealgis.ealauth.backends.CustomOAuth2")
+    SOCIAL_AUTH_CUSTOM_KEY = get_env('SOCIAL_AUTH_CUSTOM_KEY')
+    SOCIAL_AUTH_CUSTOM_SECRET = get_env('SOCIAL_AUTH_CUSTOM_SECRET')
     CUSTOM_OAUTH2_BACKEND = True
 
 AUTH_BACKENDS.append("django.contrib.auth.backends.ModelBackend")


### PR DESCRIPTION
In testing out the custom OAuth provider, I realised that some variables weren't being set that are required by the Python Social Auth library. Specifically, the variables

- SOCIAL_AUTH_NAME_KEY
- SOCIAL_AUTH_NAME_SECRET

A challenge is that these variables are named after the name of the provider ([see section 3.7.3 on page 25 of this PDF](https://media.readthedocs.org/pdf/python-social-auth/stable/python-social-auth.pdf)).

I've checked the list of Python Social Auth backends and none are named 'custom', so for the time being at least, the approach I've taken in this PR should work.
