### PR TITLE
Allow non-SSL prod deployments

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -45,5 +45,6 @@ services:
       - "443:443"
     environment:
       - HTTPS_ENABLED=TRUE
+      - ENVIRONMENT=PRODUCTION
       - SERVER_NAME=demo.ealgis.org
       - DJANGO_LOCATION=uwsgi:9090

--- a/nginx-prod/docker-entrypoint.sh
+++ b/nginx-prod/docker-entrypoint.sh
@@ -16,7 +16,11 @@ function dockerwait {
 }
 
 if [ "$HTTPS_ENABLED" = "FALSE" ]; then
+  if [ "$ENVIRONMENT" = "PRODUCTION" ]; then
+    nginxconf="/etc/nginx/docker.http.prod.conf"
+  else
     nginxconf="/etc/nginx/docker.http.conf"
+  fi
 else
     nginxconf="/etc/nginx/docker.https.conf"
 fi

--- a/nginx-prod/nginx/docker.http.prod.conf
+++ b/nginx-prod/nginx/docker.http.prod.conf
@@ -1,0 +1,46 @@
+# nginx/conf.d/docker.conf
+
+upstream django_frontend {
+    least_conn;
+    server ${DJANGO_LOCATION};
+}
+
+server {
+    listen       80;
+    
+    server_name  ${SERVER_NAME};
+    charset      utf-8;
+
+    # max upload size
+    client_max_body_size 75M;
+    
+    location / {
+       alias /frontend/;
+       try_files $uri /index.html =404;
+    }
+
+    location /api {
+       proxy_pass          http://django_frontend;
+       proxy_redirect      off;
+       proxy_set_header    Host $http_host;
+    }
+
+    location /login {
+       proxy_pass          http://django_frontend;
+       proxy_redirect      off;
+       proxy_set_header    Host $http_host;
+    }
+
+    location /admin {
+       proxy_pass          http://django_frontend;
+       proxy_redirect      off;
+       proxy_set_header    Host $http_host;
+    }
+
+    location /complete {
+       proxy_pass          http://django_frontend;
+       proxy_redirect      off;
+       proxy_set_header    Host $http_host;
+    }
+
+}


### PR DESCRIPTION
We deploy EALGIS  behind a proxy that does SSL offload. As such, we deploy with `HTTPS_ENABLED` set to `FALSE`. The changes to the nginx configuration (2.0.x.y --> 2.1.x.y) means we can't deploy the latest release.

This PR adds an `ENVIRONMENT` variable to the build and tweaks the container entrypoint script, allowing for non-SSL production deployments.

